### PR TITLE
Removes general BIND configuration

### DIFF
--- a/docs/Example.md
+++ b/docs/Example.md
@@ -29,17 +29,6 @@ BIND9 can be installed from the linux command line (as root), with the following
 sudo yum install bind bind-utils
 ```
 
-### Configure BIND - General configuration
-
-The basic BIND install provides a general config file which you can find at `/etc/named.conf`
-
-If desired, configure the next upstream DNS server - this is likely to be a corporate DNS service on the Internet the internet (`8.8.8.8`, or `1.1.1.1` for example) or might be in the local lab.
-
-```
-forwarders { 192.168.0.19; }; #IP of upstream nameserver(s)
-recursion yes;
-```
-
 ### Add the example zone to the DNS server
 
 In this example, we will be working with the domain `gplab.com`.  We must add this domain to the configuration file of the DNS server so that it knows it is responsible for responding to queries for this zone.  Zone information is kept in `/etc/named.conf` (CentOS 7), or in `/etc/named.conf.local` (Debian/Ubuntu).  To add the zone, enter the information below in the appropriate configuration file for your distribution.


### PR DESCRIPTION
This section includes information on configuring the server with a forwarder.  This is not really the main focus of this how-to.  I suggest we eliminate distractions and information that people can easily find elsewhere.