### PR TITLE
Moves secondary servers to bottom

### DIFF
--- a/docs/Example.md
+++ b/docs/Example.md
@@ -79,30 +79,193 @@ $TTL 3600
              604800 )   ; Negative Cache TTL
 ```
 
-Then we define our main and backup DNS server for this zone/domain. End-points should be configured with these DNS servers.
+Then we define our DNS server for this zone/domain. End-points should be configured with this DNS server.
 
 ```
-; DNS servers
-        IN      NS      dns1.gplab.com.
-        IN      NS      dns2.gplab.com.
+; DNS server
+        IN      NS      dns.gplab.com.
 ```
 
-DNS server records added to indicate the server supports Service Discovery:
+We add these PTR records to indicate the server supports Service Discovery.  Clients looking for DNS-SD support will query the server for these specific records.  (`b` is for `browse`.  `lb` is for `legacy browse`.)
 
 ```
-; These lines indicate to clients that this server supports DNS Service
-; Discovery
+; These lines indicate to clients that this server supports DNS Service Discovery
 b._dns-sd._udp	IN	PTR	@
 lb._dns-sd._udp	IN	PTR	@
 ```
 
-The NMOS register services are defined:
+Next we define the NMOS register services provided by this server:
 
 ```
 ; These lines indicate to clients which NMOS service types this server advertises:
 _services._dns-sd._udp	PTR	_nmos-register._tcp
 _services._dns-sd._udp	PTR	_nmos-query._tcp
 ```
+
+There should be one `PTR` record for each instance of the service you wish to advertise. Here we have one Registration API and one Query API:
+
+```
+_nmos-register._tcp	PTR	reg-api-1._nmos-register._tcp
+_nmos-query._tcp	PTR	qry-api-1._nmos-query._tcp
+```
+
+Now we add a record that indicate specifically which server provides the NMOS services.  In this case, it is `rds1.gplab.com`.
+
+```
+; NMOS RDS services
+reg-api-1._nmos-register._tcp.gplab.com.     3600    IN SRV  10      10      80      rds1.gplab.com.
+```
+
+We add a TXT record which provides information relevant to the IS-04 specification
+
+```
+; Additional metadata relevant to the IS-04 specification.
+reg-api-1._nmos-register._tcp.gplab.com.	TXT	"api_ver=v1.0,v1.1,v1.2,v1.3" "api_proto=http" "pri=0" "api_auth=false"
+```
+
+We add a record which associated the NMOS register with the RDS.
+```
+; RDS
+_nmos-register._tcp.gplab.com.     3600    IN SRV  10      20      80      rds1.gplab.com.
+```
+
+In all cases above the `SRV` records are identifying a port number of `80`. This would suit default HTTP access, with `443` needed for HTTPS - but again, this would be a question for the RDS vendor.
+
+Lastly we provide the IP addresses for the hosts in the system. This file can of course be expanded to contain names for all the hosts, end-points, and switches in the system, making debugging simpler.
+
+
+```
+; Nameserver records
+dns1.gplab.com.            IN      A       192.168.0.18
+rds1.gplab.com.            IN      A       192.168.0.50
+```
+
+
+
+### Starting the service
+
+Once the files are in place, the service can be started and made permanent (will run after a reload of the server):
+
+CentOS 7
+```
+systemctl restart named
+systemctl enable named
+```
+
+Ubuntu/Raspbian
+```
+systemctl restart bind9
+systemctl enable bind9
+```
+
+### Enabling DNS through the linux firewall
+
+Often, linux default will prevent DNS through the firewall, so you have issues with connectivity to the DNS server now running. The following will enable DNS through the CentOS 7 firewall, and make this permanent:
+
+
+```
+firewall-cmd --permanent --add-port=53/udp
+firewall-cmd --reload
+```
+
+## Testing
+
+You can test the functionality of the new DNS server right from the server itself.  You can also run these tests from a Linux box or Mac by setting the `nameserver` portion of the Linux or Mac box network configuration to point to your new DNS server.  If you run the tests below from a separate computer, omit `localhost` or `@locahost` from the commands below.
+
+There are a couple of tools that allow the DNS operation to be tested.
+
+We can verify that the host names of the RDS servers are configured:
+
+
+```
+gp@gplab.com:~ # nslookup rds1.gplab.com locahost
+Server:		192.168.0.18
+Address:	192.168.0.18#53
+
+Name:	rds1.gplab.com
+Address: 192.168.0.50
+```
+
+
+We can see that the lookup was resolved by `192.168.0.18`, and resulted in the address for the `rds1` server being returned as `192.168.0.50`.
+
+The `dig` tool provides a little more info:
+
+```
+gp@gplab.com:~ # dig @localhost rds1.gplab.com
+
+; <<>> DiG 9.10.6 <<>> rds1.gplab.com
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12178
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 2, ADDITIONAL: 3
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;rds1.gplab.com.		IN	A
+
+;; ANSWER SECTION:
+rds1.gplab.com.	3600	IN	A	192.168.0.50
+
+;; AUTHORITY SECTION:
+gplab.com.		3600	IN	NS	dns2.gplab.com.
+gplab.com.		3600	IN	NS	dns1.gplab.com.
+
+;; ADDITIONAL SECTION:
+dns1.gplab.com.	3600	IN	A	192.168.0.18
+dns2.gplab.com.	3600	IN	A	192.168.0.20
+
+;; Query time: 43 msec
+;; SERVER: 192.168.0.18#53(192.168.0.18)
+;; WHEN: Tue Jul 13 19:58:50 IST 2021
+;; MSG SIZE  rcvd: 134
+```
+
+### Checking the SRV records
+
+We can also use `dig` to check the presence of the `_nmos._register_.tcp` record:
+
+
+```
+gp@gplab.com:~ # dig @localhost _nmos-register._tcp.gplab.com SRV
+
+; <<>> DiG 9.10.6 <<>> _nmos-register._tcp.gplab.com SRV
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44496
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 2, ADDITIONAL: 5
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;_nmos-register._tcp.gplab.com. IN	SRV
+
+;; ANSWER SECTION:
+_nmos-register._tcp.gplab.com. 3600 IN SRV	10 10 80 rds1.gplab.com.
+_nmos-register._tcp.gplab.com. 3600 IN SRV	20 10 80 rds2.gplab.com.
+
+;; AUTHORITY SECTION:
+gplab.com.		3600	IN	NS	dns2.gplab.com.
+gplab.com.		3600	IN	NS	dns1.gplab.com.
+
+;; ADDITIONAL SECTION:
+rds1.gplab.com.	3600	IN	A	192.168.0.50
+rds2.gplab.com.	3600	IN	A	192.168.0.51
+dns1.gplab.com.	3600	IN	A	192.168.0.18
+dns2.gplab.com.	3600	IN	A	192.168.0.20
+
+;; Query time: 41 msec
+;; SERVER: 192.168.0.18#53(192.168.0.18)
+;; WHEN: Tue Jul 13 20:00:53 IST 2021
+;; MSG SIZE  rcvd: 243
+```
+
+## Backing Up DNS (BIND) Servers
+
+To provide resilience, a secondary DNS server and a secondary RDS server should be provisioned. end-points should have both DNS IP addresses configured, allowing them to use the backup DNS server, if the primary is no longer available.
+
+BIND allows primary / secondary pairing, so that the zones and hosts configuration can be automatically updated on the secondary device, reducing the amount of duplication.
 
 There should be one `PTR` record for each instance of the service you wish to advertise. Here we have one Registration API and one Query API:
 
@@ -154,130 +317,3 @@ dns2.gplab.com.            IN      A       192.168.0.20
 rds1.gplab.com.            IN      A       192.168.0.50
 rds2.gplab.com.            IN      A       192.168.0.51
 ```
-
-
-
-### Starting the service
-
-Once the files are in place, the service can be started and made permanent (will run after a reload of the server):
-
-CentOS 7
-```
-systemctl restart named
-systemctl enable named
-```
-
-Ubuntu/Raspbian
-```
-systemctl restart bind9
-systemctl enable bind9
-```
-
-### Enabling DNS through the linux firewall
-
-Often, linux default will prevent DNS through the firewall, so you have issues with connectivity to the DNS server now running. The following will enable DNS through the CentOS 7 firewall, and make this permanent:
-
-
-```
-firewall-cmd --permanent --add-port=53/udp
-firewall-cmd --reload
-```
-
-## Testing
-
-You can test the functionality of the new DNS server right from the server itself.  You can also run these tests from a Linux box or Mac by setting the `nameserver` portion of the Linux or Mac box network configuration to point to your new DNS server.  If you run the tests below from a separate computer, omit `localhost` or `@locahost` from the commands below.
-
-There are a couple of tools that allow the DNS operation to be tested.
-
-We can verify that the host names of the RDS servers are configured:
-
-
-```
-gparistacom:~ gparista.com$ nslookup rds1.gplab.com locahost
-Server:		192.168.0.18
-Address:	192.168.0.18#53
-
-Name:	rds1.gplab.com
-Address: 192.168.0.50
-```
-
-
-We can see that the lookup was resolved by `192.168.0.18`, and resulted in the address for the `rds1` server being returned as `192.168.0.50`.
-
-The `dig` tool provides a little more info:
-
-```
-gparistacom:~ gparista.com$ dig @localhost rds1.gplab.com
-
-; <<>> DiG 9.10.6 <<>> rds1.gplab.com
-;; global options: +cmd
-;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12178
-;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 2, ADDITIONAL: 3
-
-;; OPT PSEUDOSECTION:
-; EDNS: version: 0, flags:; udp: 4096
-;; QUESTION SECTION:
-;rds1.gplab.com.		IN	A
-
-;; ANSWER SECTION:
-rds1.gplab.com.	3600	IN	A	192.168.0.50
-
-;; AUTHORITY SECTION:
-gplab.com.		3600	IN	NS	dns2.gplab.com.
-gplab.com.		3600	IN	NS	dns1.gplab.com.
-
-;; ADDITIONAL SECTION:
-dns1.gplab.com.	3600	IN	A	192.168.0.18
-dns2.gplab.com.	3600	IN	A	192.168.0.20
-
-;; Query time: 43 msec
-;; SERVER: 192.168.0.18#53(192.168.0.18)
-;; WHEN: Tue Jul 13 19:58:50 IST 2021
-;; MSG SIZE  rcvd: 134
-```
-
-### Checking the SRV records
-
-We can also use `dig` to check the presence of the `_nmos._register_.tcp` record:
-
-
-```
-gparistacom:~ gparista.com$ dig @localhost _nmos-register._tcp.gplab.com SRV
-
-; <<>> DiG 9.10.6 <<>> _nmos-register._tcp.gplab.com SRV
-;; global options: +cmd
-;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44496
-;; flags: qr aa rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 2, ADDITIONAL: 5
-
-;; OPT PSEUDOSECTION:
-; EDNS: version: 0, flags:; udp: 4096
-;; QUESTION SECTION:
-;_nmos-register._tcp.gplab.com. IN	SRV
-
-;; ANSWER SECTION:
-_nmos-register._tcp.gplab.com. 3600 IN SRV	10 10 80 rds1.gplab.com.
-_nmos-register._tcp.gplab.com. 3600 IN SRV	20 10 80 rds2.gplab.com.
-
-;; AUTHORITY SECTION:
-gplab.com.		3600	IN	NS	dns2.gplab.com.
-gplab.com.		3600	IN	NS	dns1.gplab.com.
-
-;; ADDITIONAL SECTION:
-rds1.gplab.com.	3600	IN	A	192.168.0.50
-rds2.gplab.com.	3600	IN	A	192.168.0.51
-dns1.gplab.com.	3600	IN	A	192.168.0.18
-dns2.gplab.com.	3600	IN	A	192.168.0.20
-
-;; Query time: 41 msec
-;; SERVER: 192.168.0.18#53(192.168.0.18)
-;; WHEN: Tue Jul 13 20:00:53 IST 2021
-;; MSG SIZE  rcvd: 243
-```
-
-## Backing Up DNS (BIND) Servers
-
-To provide resilience, a secondary DNS server should be provisioned. end-points should have both DNS IP addresses configured, allowing them to use the backup DNS server, if the primary is no longer available.
-
-BIND allows primary / secondary pairing, so that the zones and hosts configuration can be automatically updated on the secondary device, reducing the amount of duplication.


### PR DESCRIPTION
Simplified example by moving all text about primary and secondary servers to the bottom of the example.  That way people will start with a very basic example that simply responds to DNS-SD queries.  We need to complete the section at the bottom now, taking into account #7.